### PR TITLE
Implement xz packing and new versioning

### DIFF
--- a/debrepo.py
+++ b/debrepo.py
@@ -252,15 +252,19 @@ def split_pkg_path(pkg_path):
     expr = r'^(?P<package>[^_]+)_(?P<version>[0-9]+(\.[0-9]+){2,3}(\.g[a-f0-9]+)?\-[0-9])(\.(?P<revision>[^\-]+))?([\-]?(?P<dist>[^_]+))?_(?P<arch>[^\.]+)\.deb$'
     match_package = re.match(expr, pkg_path)
 
-    if not match:
+    # The distribution information may be missing in the file name,
+    # but present in the path.
+    match_path = re.match('^pool/(?P<dist>[^/]+)/main', pkg_path)
+
+    if not match_package:
         return None
 
     component = 'main'
 
-    dist = match.group('dist')
+    dist = match_package.group('dist') or match_path.group('dist')
     if dist is None:
         dist = 'all'
-    arch = match.group('arch')
+    arch = match_package.group('arch')
     if arch is None:
         arch = 'all'
 

--- a/debrepo.py
+++ b/debrepo.py
@@ -77,8 +77,12 @@ class Package(object):
         self.fields = collections.OrderedDict()
 
     def parse_deb(self, debfile):
-        cmd = 'ar -p ' + debfile + ' control.tar.gz |' + \
-              'tar -xzf - --to-stdout ./control'
+        if subprocess.call('ar t ' + debfile + ' | grep control.tar.gz', shell=True) == 0:
+            cmd = 'ar -p ' + debfile + ' control.tar.gz |' + \
+                  'tar -xzf - --to-stdout ./control'
+        else:
+            cmd = 'ar -p ' + debfile + ' control.tar.xz |' + \
+                  'tar -xJf - --to-stdout ./control'
 
         control = subprocess.check_output(cmd, shell=True)
         self.parse_string(control.strip())

--- a/debrepo.py
+++ b/debrepo.py
@@ -249,8 +249,8 @@ def split_pkg_path(pkg_path):
     # We assume that DEB file format is the following, with optional <revision>, <dist> and <arch>
     # <package>_<version>.<revision>-<dist>_<arch>.deb
 
-    expr = r'^(?P<package>[^_]+)_(?P<version>[0-9]+\.[0-9]+\.[0-9]+\-[0-9]+)(\.(?P<revision>[^\-]+))?([\-]?(?P<dist>[^_]+))?_(?P<arch>[^\.]+)\.deb$'
-    match = re.match(expr, pkg_path)
+    expr = r'^(?P<package>[^_]+)_(?P<version>[0-9]+(\.[0-9]+){2,3}(\.g[a-f0-9]+)?\-[0-9])(\.(?P<revision>[^\-]+))?([\-]?(?P<dist>[^_]+))?_(?P<arch>[^\.]+)\.deb$'
+    match_package = re.match(expr, pkg_path)
 
     if not match:
         return None


### PR DESCRIPTION
Since the latest ubuntu/bionic the new default pack
format for debian packages is in use by dpkg tool:
    tar.gz -> tar.xz
also Tarantool core packages uses versioning names like:
    tarantool_2.3.0.62.g6c627af39-1_amd64.deb
but not as expected:
    tarantool_2.3.0-62.g6c627af39-1_amd64.deb

Closes #14