### PR TITLE
rpm: fix sync of live/1.10/el/7/x86_64 repo 

### DIFF
--- a/rpmrepo.py
+++ b/rpmrepo.py
@@ -492,7 +492,23 @@ def dump_primary(primary):
 
         res += '    <rpm:provides>\n'
 
-        for key in sorted(fmt['provides']):
+        def sort_key(item):
+            # Examples of an `item`:
+            #   ('tarantool-lrexlib-pcre', '0', None, '2.9.0.5')
+            #   ('tarantool-lrexlib-pcre', '0', '1.el7.centos', '2.9.0.5')
+            #
+            # If there is a `None` value among `str` values, we need to convert it to an empty
+            # string to avoid the following error:
+            #   TypeError: '<' not supported between instances of 'str' and 'NoneType'
+            if None in item[1:] and any(item[1:]):
+                item_custom = list(item)
+                for i, v in enumerate(item_custom[:]):
+                    if v is None:
+                        item_custom[i] = ""
+                return tuple(item_custom)
+            return item
+
+        for key in sorted(fmt['provides'], key=sort_key):
             provides = fmt['provides'][key]
             entry = ['name="%s"' % provides['name']]
             for component in ['flags', 'epoch', 'ver', 'rel']:
@@ -505,7 +521,7 @@ def dump_primary(primary):
 
         res += '    <rpm:requires>\n'
 
-        for key in sorted(fmt['requires']):
+        for key in sorted(fmt['requires'], key=sort_key):
             requires = fmt['requires'][key]
             entry = ['name="%s"' % requires['name']]
             for component in ['flags', 'epoch', 'ver', 'rel', 'pre']:
@@ -518,7 +534,7 @@ def dump_primary(primary):
 
         res += '    <rpm:obsoletes>\n'
 
-        for key in sorted(fmt['obsoletes']):
+        for key in sorted(fmt['obsoletes'], key=sort_key):
             obsoletes = fmt['obsoletes'][key]
             entry = ['name="%s"' % obsoletes['name']]
             for component in ['flags', 'epoch', 'ver', 'rel']:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from setuptools import setup
 from os import path
+
+from setuptools import setup
 
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:

--- a/test/test_rpmrepo.py
+++ b/test/test_rpmrepo.py
@@ -83,3 +83,128 @@ class TestRPMRepo(unittest.TestCase):
         self.assertIsNone(initial_filelists)
         self.assertIsNone(initial_primary)
         self.assertIsNone(initial_others)
+
+    def test_dump_primary(self):
+        primary = {
+            ('tarantool-lrexlib-pcre', '0', '1.el7.centos', '2.9.0.5'): {
+                'checksum': '69743803d280e7e92165bb7b1926330cf8041cae56ab83f2f07bb35485e81a30',
+                'name': 'tarantool-lrexlib-pcre',
+                'arch': 'x86_64',
+                'version': {'ver': '2.9.0.5', 'rel': '1.el7.centos', 'epoch': '0'},
+                'summary': None,
+                'description': None,
+                'packager': None,
+                'url': 'https://github.com/tarantool/lrexlib',
+                'file_time': '1655216309',
+                'build_time': 1541643049,
+                'package_size': 20780,
+                'installed_size': 42856,
+                'archive_size': 43124,
+                'location': 'Packages/tarantool-lrexlib-pcre-2.9.0.5-1.el7.centos.x86_64.rpm',
+                'format': {
+                    'license': 'MIT',
+                    'vendor': None,
+                    'group': None,
+                    'buildhost': '5d6663a7b0f9',
+                    'sourcerpm': 'tarantool-lrexlib-2.9.0.5-1.el7.centos.src.rpm',
+                    'header_start': 280,
+                    'header_end': 6104,
+                    'provides': {
+                        ('tarantool-lrexlib-pcre', '0', None, '2.9.0.5'): {
+                            'name': 'tarantool-lrexlib-pcre', 'epoch': '0', 'rel': None,
+                            'ver': '2.9.0.5', 'flags': 'EQ'},
+                        ('tarantool-lrexlib-pcre', '0', '1.el7.centos', '2.9.0.5'): {
+                            'name': 'tarantool-lrexlib-pcre', 'epoch': '0', 'rel': '1.el7.centos',
+                            'ver': '2.9.0.5', 'flags': 'EQ'},
+                        ('tarantool-lrexlib-pcre(x86-64)', '0', '1.el7.centos', '2.9.0.5'): {
+                            'name': 'tarantool-lrexlib-pcre(x86-64)', 'epoch': '0',
+                            'rel': '1.el7.centos', 'ver': '2.9.0.5', 'flags': 'EQ'}
+                    },
+                    'requires': {
+                        ('libc.so.6()(64bit)', None, None, None): {
+                            'name': 'libc.so.6()(64bit)', 'epoch': None,
+                            'rel': None, 'ver': None, 'flags': None, 'pre': None},
+                        ('libc.so.6(GLIBC_2.14)(64bit)', None, None, None): {
+                            'name': 'libc.so.6(GLIBC_2.14)(64bit)', 'epoch': None,
+                            'rel': None, 'ver': None, 'flags': None, 'pre': None},
+                        ('libc.so.6(GLIBC_2.2.5)(64bit)', None, None, None): {
+                            'name': 'libc.so.6(GLIBC_2.2.5)(64bit)', 'epoch': None,
+                            'rel': None, 'ver': None, 'flags': None, 'pre': None},
+                        ('libc.so.6(GLIBC_2.3)(64bit)', None, None, None): {
+                            'name': 'libc.so.6(GLIBC_2.3)(64bit)', 'epoch': None,
+                            'rel': None, 'ver': None, 'flags': None, 'pre': None},
+                        ('libc.so.6(GLIBC_2.3.4)(64bit)', None, None, None): {
+                            'name': 'libc.so.6(GLIBC_2.3.4)(64bit)', 'epoch': None,
+                            'rel': None, 'ver': None, 'flags': None, 'pre': None},
+                        ('libc.so.6(GLIBC_2.4)(64bit)', None, None, None): {
+                            'name': 'libc.so.6(GLIBC_2.4)(64bit)', 'epoch': None,
+                            'rel': None, 'ver': None, 'flags': None, 'pre': None},
+                        ('libpcre.so.1()(64bit)', None, None, None): {
+                            'name': 'libpcre.so.1()(64bit)', 'epoch': None,
+                            'rel': None, 'ver': None, 'flags': None, 'pre': None},
+                        ('pcre', None, None, None): {
+                            'name': 'pcre', 'epoch': None,
+                            'rel': None, 'ver': None, 'flags': None, 'pre': None},
+                        ('rtld(GNU_HASH)', None, None, None): {
+                            'name': 'rtld(GNU_HASH)', 'epoch': None,
+                            'rel': None, 'ver': None, 'flags': None, 'pre': None},
+                        ('tarantool', '0', None, '1.9.0.0'): {
+                            'name': 'tarantool', 'epoch': '0',
+                            'rel': None, 'ver': '1.9.0.0', 'flags': 'GT', 'pre': None}
+                    },
+                    'obsoletes': {},
+                    'files': [
+                        {'name': '/usr/lib64/tarantool/rex_pcre.so', 'type': 'file'},
+                        {'name': '/usr/lib64/tarantool/', 'type': 'dir'}
+                    ]
+                }
+            }
+        }
+        primary_str = """<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://linux.duke.edu/metadata/common" \
+xmlns:rpm="http://linux.duke.edu/metadata/rpm" packages="1">
+<package type="rpm">
+  <name>tarantool-lrexlib-pcre</name>
+  <arch>x86_64</arch>
+  <version epoch="0" ver="2.9.0.5" rel="1.el7.centos"/>
+  <checksum type="sha256" \
+pkgid="YES">69743803d280e7e92165bb7b1926330cf8041cae56ab83f2f07bb35485e81a30</checksum>
+  <summary></summary>
+  <description></description>
+  <packager></packager>
+  <url>https://github.com/tarantool/lrexlib</url>
+  <time file="1655216309" build="1541643049"/>
+  <size package="20780" installed="42856" archive="43124"/>
+  <location href="Packages/tarantool-lrexlib-pcre-2.9.0.5-1.el7.centos.x86_64.rpm"/>
+  <format>
+    <rpm:license>MIT</rpm:license>
+    <rpm:group></rpm:group>
+    <rpm:buildhost>5d6663a7b0f9</rpm:buildhost>
+    <rpm:sourcerpm>tarantool-lrexlib-2.9.0.5-1.el7.centos.src.rpm</rpm:sourcerpm>
+    <rpm:header-range start="280" end="6104"/>
+    <rpm:provides>
+      <rpm:entry name="tarantool-lrexlib-pcre" flags="EQ" epoch="0" ver="2.9.0.5"/>
+      <rpm:entry name="tarantool-lrexlib-pcre" flags="EQ" epoch="0" ver="2.9.0.5" \
+rel="1.el7.centos"/>
+      <rpm:entry name="tarantool-lrexlib-pcre(x86-64)" flags="EQ" epoch="0" ver="2.9.0.5" \
+rel="1.el7.centos"/>
+    </rpm:provides>
+    <rpm:requires>
+      <rpm:entry name="libc.so.6()(64bit)"/>
+      <rpm:entry name="libc.so.6(GLIBC_2.14)(64bit)"/>
+      <rpm:entry name="libc.so.6(GLIBC_2.2.5)(64bit)"/>
+      <rpm:entry name="libc.so.6(GLIBC_2.3)(64bit)"/>
+      <rpm:entry name="libc.so.6(GLIBC_2.3.4)(64bit)"/>
+      <rpm:entry name="libc.so.6(GLIBC_2.4)(64bit)"/>
+      <rpm:entry name="libpcre.so.1()(64bit)"/>
+      <rpm:entry name="pcre"/>
+      <rpm:entry name="rtld(GNU_HASH)"/>
+      <rpm:entry name="tarantool" flags="GT" epoch="0" ver="1.9.0.0"/>
+    </rpm:requires>
+    <rpm:obsoletes>
+    </rpm:obsoletes>
+  </format>
+</package>
+</metadata>
+"""
+        self.assertEqual(rpmrepo.dump_primary(primary), primary_str)


### PR DESCRIPTION
This patch fixes the issue occurred while syncing live/1.10/el/7/x86_64
tarantool repo:

    2022-06-01T15:43:52.167754425Z app[web.1]: Traceback (most recent call last):
    2022-06-01T15:43:52.167954314Z app[web.1]:   File "/app/.heroku/python/bin/mkrepo", line 5, in <module>
    2022-06-01T15:43:52.167969891Z app[web.1]:     mkrepo.main()
    2022-06-01T15:43:52.167979377Z app[web.1]:   File "/app/.heroku/python/lib/python3.9/site-packages/mkrepo.py", line 117, in main
    2022-06-01T15:43:52.168122234Z app[web.1]:     update_repo(path, args)
    2022-06-01T15:43:52.168157987Z app[web.1]:   File "/app/.heroku/python/lib/python3.9/site-packages/mkrepo.py", line 59, in update_repo
    2022-06-01T15:43:52.168168105Z app[web.1]:     rpmrepo.update_repo(stor, args.sign, args.temp_dir, args.force)
    2022-06-01T15:43:52.168177668Z app[web.1]:   File "/app/.heroku/python/lib/python3.9/site-packages/rpmrepo.py", line 1097, in update_repo
    2022-06-01T15:43:52.168187173Z app[web.1]:     primary_str = dump_primary(primary)
    2022-06-01T15:43:52.168196066Z app[web.1]:   File "/app/.heroku/python/lib/python3.9/site-packages/rpmrepo.py", line 495, in dump_primary
    2022-06-01T15:43:52.168413070Z app[web.1]:     for key in sorted(fmt['provides']):
    2022-06-01T15:43:52.168456583Z app[web.1]: TypeError: '<' not supported between instances of 'str' and 'NoneType'
    2022-06-01T15:43:52.253078579Z app[web.1]: 2022-06-01 15:43:52,252 (WARNING) Synchronization failed: live/1.10/el/7/x86_64

As we can see from the traceback, the `sorted()` function cannot sort
keys from the `fmt['provides']` dict because these keys are tuples with
different types of items (None and str). So the `sort_key` function was
introdused to handle such cases. Also, a test was added.

Fixes #62