### PR TITLE
Fix2 dump primary func

### DIFF
--- a/rpmrepo.py
+++ b/rpmrepo.py
@@ -500,7 +500,8 @@ def dump_primary(primary):
             # If there is a `None` value among `str` values, we need to convert it to an empty
             # string to avoid the following error:
             #   TypeError: '<' not supported between instances of 'str' and 'NoneType'
-            if None in item[1:] and any(item[1:]):
+            # Note, there can be cases when all item[1:] values are None.
+            if None in item[1:]:
                 item_custom = list(item)
                 for i, v in enumerate(item_custom[:]):
                     if v is None:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 setup(
     name='mkrepo',
     packages=[''],
-    version='0.1.7',
+    version='0.1.8',
     description='Maintain deb and rpm repos on s3',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This patch fixes the issue 
```
TypeError: '<' not supported between instances of 'str' and 'NoneType'
```
occurred while syncing one of our local rpm repositories. There's a case when every **item[1:]** list value is **NoneType**

following up on #63 