### PR TITLE
rpm: xml.etree.ElementTree.ParseError: not well-formed (invalid token)

### DIFF
--- a/rpmrepo.py
+++ b/rpmrepo.py
@@ -478,7 +478,7 @@ def dump_primary(primary):
 
         res += '  <format>\n'
 
-        res += '    <rpm:license>%s</rpm:license>\n' % fmt['license']
+        res += '    <rpm:license>%s</rpm:license>\n' % escape(fmt['license'])
 
         if fmt['vendor']:
             res += '    <rpm:vendor>%s</rpm:vendor>\n' % escape(fmt['vendor'])


### PR DESCRIPTION
The license XML tag may contain an ampersand character that should be
escaped, otherwise, it leads to the following error:

    xml.etree.ElementTree.ParseError: not well-formed (invalid token)

As a result, it renders repository unusable. This patch fixes the issue
by escaping the `fmt['license']` value in the `dump_primary` function.

Example:

    <rpm:license>OpenSSL & Chromium CLA</rpm:license>      <-- before
    <rpm:license>OpenSSL &amp; Chromium CLA</rpm:license>  <-- after