### PR TITLE
rpm: process i18nstring header types

### DIFF
--- a/rpmfile.py
+++ b/rpmfile.py
@@ -400,7 +400,7 @@ class RpmInfo(object):
                     value.append(struct.unpack('>q', f.read(8))[0])
                 if len(value) == 1:
                     value = value[0]
-            elif type == 6:
+            elif type == 6 or type == 9:
                 char = None
                 string = b''
                 while True:

--- a/rpmrepo.py
+++ b/rpmrepo.py
@@ -750,8 +750,21 @@ def header_to_primary(
         size):
     name = get_with_decode(header, 'NAME', None)
     arch = get_arch_from_header(header)
-    summary = get_with_decode(header, 'SUMMARY')
-    description = get_with_decode(header, 'DESCRIPTION')
+
+    try:
+        summary = get_with_decode(header, 'SUMMARY')
+    except UnicodeDecodeError:
+        summary = get_with_decode(
+            header, 'SUMMARY', encoding='latin-1'
+        ).encode('utf-8').decode('utf-8')
+
+    try:
+        description = get_with_decode(header, 'DESCRIPTION')
+    except UnicodeDecodeError:
+        description = get_with_decode(
+            header, 'DESCRIPTION', encoding='latin-1'
+        ).encode('utf-8').decode('utf-8')
+
     packager = get_with_decode(header, 'PACKAGER', None)
     build_time = header.get('BUILDTIME', '')
     url = get_with_decode(header, 'URL')


### PR DESCRIPTION
SUMMARY, DESCRITPTION and GROUP header entry values were None. The fields are [RPM_I18NSTRING_TYPE](https://github.com/rpm-software-management/rpm/blob/master/lib/header.c#L41) types (type == 9). 

```
tag, type, offset, count
(1004, 9, 23, 1)
(1005, 9, 50, 1)
```
```
SUMMARY: None
DESCRIPTION: None
GROUP: None
```