### PR TITLE
rpm: fix primary.xml

### DIFF
--- a/rpmfile.py
+++ b/rpmfile.py
@@ -14,7 +14,7 @@ RPMSENSE_ANY = 0
 RPMSENSE_LESS = 1 << 1
 RPMSENSE_GREATER = 1 << 2
 RPMSENSE_EQUAL = 1 << 3
-RPMSENSE_SENSEMASK = 0x0e
+RPMSENSE_SENSEMASK = 0x0f
 RPMSENSE_NOTEQUAL = RPMSENSE_EQUAL ^ RPMSENSE_SENSEMASK
 
 RPMSENSE_PROVIDES = (1 << 4)
@@ -44,24 +44,21 @@ RPMSENSE_CONFIG = (1 << 28)
 
 
 def flags_to_str(flags):
-    flags = flags & 0x0e
+    flags = flags & RPMSENSE_SENSEMASK
 
-    if flags == RPMSENSE_NOTEQUAL:
-        return "NE"
-    elif flags == RPMSENSE_EQUAL:
-        return "EQ"
-    elif flags & RPMSENSE_LESS:
-        return "LT"
-    elif flags & RPMSENSE_GREATER:
-        return "GT"
-    elif flags & (RPMSENSE_LESS | RPMSENSE_EQUAL):
-        return "LE"
-    elif flags & (RPMSENSE_GREATER | RPMSENSE_EQUAL):
-        return "GE"
-    elif flags == 0:
+    if flags == 0:
         return None
-    else:
-        raise RuntimeError("Unknown flags: %d" % flags)
+    elif flags == 2:
+        return "LT"
+    elif flags == 4:
+        return "GT"
+    elif flags == 8:
+        return "EQ"
+    elif flags == 10:
+        return "LE"
+    elif flags == 12:
+        return "GE"
+    return None
 
 
 SIGNATURE_TAG_TABLE = {

--- a/rpmrepo.py
+++ b/rpmrepo.py
@@ -1192,7 +1192,7 @@ def update_repo(storage, sign, tempdir, force=False):
 def main():
     stor = storage.FilesystemStorage(sys.argv[1])
 
-    update_repo(stor)
+    update_repo(stor, sign=False, tempdir='/tmp')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Adding “primary” files into primary.xml. The [rpm-software-management/createrepo_c](https://github.com/rpm-software-management/createrepo_c/blob/d8da644c45bec1429d600c619ce4e47af5906ef8/src/misc.h#L110) source code. 
Doing it the right way using FILEMODES rpm header field. With FILEMODES, we can distinguish files (symlinks, regular files) from directories.
2. Converting flags to string exactly as [rpm-software-management/createrepo_c](https://github.com/rpm-software-management/createrepo_c/blob/d8da644c45bec1429d600c619ce4e47af5906ef8/src/misc.c#L51) does, RPMSENSE_SENSEMASK bit mask is set to [15](https://github.com/rpm-software-management/rpm/blob/bf1771b/include/rpm/rpmds.h#L61).
3. Fix rpmrepo.py when it is going to be run as a separate script (convenient for debugging on
local file system).