### PR TITLE
ci: bump checkout and setup-python action versions

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# IDEA
+.idea/


### PR DESCRIPTION
Eliminate the following warning:

    Node.js 12 actions are deprecated. For more information see:
    https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
    Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2