### PR TITLE
rpm: python36 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- RPM:
+  * Fix Python 3.6 compatibility by replacing the `removesuffix()` method, which 
+    is available since Python 3.9.0, with another code.
+
 ### Changed
 
 - Use the `python3` shebang instead of `python` in the `mkrepo` executable path.

--- a/rpmrepo.py
+++ b/rpmrepo.py
@@ -544,8 +544,8 @@ def compare_dependency(dep1: str, dep2: str) -> int:
     ver2 = ver2[ver2_num_idx:]
 
     # Get version string
-    ver1 = ver1.removesuffix(ver1_e)
-    ver2 = ver2.removesuffix(ver2_e)
+    ver1 = ver1[:-len(ver1_e)]
+    ver2 = ver2[:-len(ver2_e)]
 
     ret1 = compare_rpm_versions(ver1, ver2)
     if ret1 == -1:


### PR DESCRIPTION
Fix Python 3.6 compatibility by replacing the `removesuffix()` method, which 
is available since Python 3.9.0, with another code.