### PR TITLE
exe: use `python3` shebang instead of `python`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Use the `python3` shebang instead of `python` in the `mkrepo` executable path.
+
 ### Added
 
 - Add auto-installation of required package dependencies.

--- a/mkrepo
+++ b/mkrepo
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import mkrepo
 


### PR DESCRIPTION
Use the `python3` shebang in the executable `mkrepo` script to ensure running mkrepo in a Python 3 environment since Python 2 support is dropped.