### PR TITLE
bugfix: epoch="0"

### DIFF
--- a/rpmrepo.py
+++ b/rpmrepo.py
@@ -209,7 +209,7 @@ def dump_filelists(filelists):
 
         res += '  <version '
         components = ' '.join(['%s="%s"' % (c, ver[c])
-                               for c in ['epoch', 'ver', 'rel'] if ver[c]])
+                               for c in ['epoch', 'ver', 'rel'] if c in ver])
         res += '%s/>\n' % components
 
         for fileentry in package['files']:
@@ -572,7 +572,7 @@ def dump_primary(primary):
         ver = package['version']
         res += '  <version '
         components = ' '.join(['%s="%s"' % (c, ver[c])
-                               for c in ['epoch', 'ver', 'rel'] if ver[c]])
+                               for c in ['epoch', 'ver', 'rel'] if c in ver])
         res += '%s/>\n' % components
 
         res += '  <checksum type="sha256" pkgid="YES">%s</checksum>\n' % (
@@ -821,7 +821,7 @@ def dump_other(other):
 
         res += '  <version '
         components = ' '.join(
-            ['%s="%s"' % (c, ver[c]) for c in ['epoch', 'ver', 'rel'] if ver[c]])
+            ['%s="%s"' % (c, ver[c]) for c in ['epoch', 'ver', 'rel'] if c in ver])
         res += '%s/>\n' % components
 
         for changelog in log:


### PR DESCRIPTION
Fix issue https://github.com/tarantool/mkrepo/issues/87
```
ver = {'ver': '2.7.7', 'rel': '30.el7', 'epoch': 0}
print(  ' '.join(['%s="%s"' % (c, ver[c]) for c in ['epoch', 'ver', 'rel'] if ver[c] ])  )
```

ver="2.7.7" rel="30.el7"

```
ver = {'ver': '2.7.7', 'rel': '30.el7', 'epoch': 0}
print(  ' '.join(['%s="%s"' % (c, ver[c]) for c in ['epoch', 'ver', 'rel'] if c in ver])  )

```
epoch="0" ver="2.7.7" rel="30.el7"

## because if epoch="0"  =>  if ver[c]  =>  if 0  =>  False